### PR TITLE
don't decide too much on a library level where avatars should be shown

### DIFF
--- a/models/messagesmodel.cpp
+++ b/models/messagesmodel.cpp
@@ -190,7 +190,7 @@ QVariant MessagesModel::data(const QModelIndex &index, int role) const
 
     if(role == MessagesModel::NeedsPeerImageRole)
     {
-        if(!TelegramHelper::isChat(this->_dialog) || message->isOut() || (message->constructorId() == TLTypes::MessageService))
+        if(message->constructorId() == TLTypes::MessageService)
             return false;
 
         if(message != this->_messages.last())


### PR DESCRIPTION
when avatars should be shown can depend on many things that the library is not aware of. For instance the window size might play a role. Because of that, this decision should be taken on the ui level.