### PR TITLE
Add a Message* get(index) to the messagesmodel

### DIFF
--- a/models/messagesmodel.cpp
+++ b/models/messagesmodel.cpp
@@ -51,6 +51,14 @@ void MessagesModel::setIsMuted(bool ismuted)
     emit isMutedChanged();
 }
 
+Message *MessagesModel::get(int index) const
+{
+    if (index >= 0 && index < _messages.count()) {
+        return _messages.at(index);
+    }
+    return nullptr;
+}
+
 QString MessagesModel::title() const
 {
     if(!this->_telegram)

--- a/models/messagesmodel.h
+++ b/models/messagesmodel.h
@@ -72,6 +72,7 @@ class MessagesModel : public TelegramModel
         void setDialog(Dialog* dialog);
         void setIsActive(bool isactive);
         void setIsMuted(bool ismuted);
+        Q_INVOKABLE Message* get(int index) const;
 
     public: // Overrides
         virtual bool canFetchMore(const QModelIndex&) const;


### PR DESCRIPTION
This is required in order to have a multiple selection for messages to forward. As the delegates of the selected items might be destroyed because being outside of the cacheBuffer, it is not possible to access model.item from there in order to obtain the Message* object required to forward a message.