### PR TITLE
add QString ContactsModel::dialogTitle(Dialog* dialog)

### DIFF
--- a/models/dialogsmodel.cpp
+++ b/models/dialogsmodel.cpp
@@ -264,6 +264,11 @@ void DialogsModel::clearHistory(int index)
     });
 }
 
+QString DialogsModel::dialogTitle(Dialog *dialog) const
+{
+    return this->_telegram->dialogTitle(dialog);
+}
+
 void DialogsModel::doRemoveDialog(int index)
 {
     Dialog* dialog = this->_dialogs[index];

--- a/models/dialogsmodel.h
+++ b/models/dialogsmodel.h
@@ -44,6 +44,7 @@ class DialogsModel : public TelegramModel
         Dialog* getDialog(TLInt dialogid) const;
         void removeDialog(int index);
         void clearHistory(int index);
+        QString dialogTitle(Dialog* dialog) const;
 
     private:
         void doRemoveDialog(int index);


### PR DESCRIPTION
this is useful when it is required to ask the user for confirmation
before actually opening a dialog and the request doesn't come
from a model delegate.